### PR TITLE
Added ability to execute boot jars as Diego tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 bin
 build
 dump.rdb
+.idea
+*.iml
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 23 16:43:50 EST 2015
+#Tue Jun 23 11:53:07 CDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/src/main/java/xolpoc/admin/app/Admin.java
+++ b/src/main/java/xolpoc/admin/app/Admin.java
@@ -16,6 +16,10 @@
 
 package xolpoc.admin.app;
 
+import xolpoc.admin.web.AdminController;
+import xolpoc.admin.web.StreamController;
+import xolpoc.admin.web.TaskController;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -38,16 +42,13 @@ import org.springframework.xd.dirt.rest.TempAccessControlInterceptor;
 import org.springframework.xd.dirt.rest.metrics.AggregateCountersController;
 import org.springframework.xd.dirt.rest.metrics.FieldValueCountersController;
 
-import xolpoc.admin.web.AdminController;
-import xolpoc.admin.web.StreamController;
-
 /**
  * @author Mark Fisher
  */
 @SpringBootApplication
 @EnableAutoConfiguration(exclude={DataSourceAutoConfiguration.class})
 @ImportResource("classpath*:/META-INF/spring-xd/analytics/redis-analytics.xml")
-@Import({AdminController.class, StreamController.class})
+@Import({AdminController.class, StreamController.class, TaskController.class})
 public class Admin {
 
 	public static void main(String[] args) throws Exception {

--- a/src/main/java/xolpoc/admin/web/TaskController.java
+++ b/src/main/java/xolpoc/admin/web/TaskController.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xolpoc.admin.web;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import xolpoc.model.TaskDescriptor;
+import xolpoc.model.TaskStatus;
+import xolpoc.spi.TaskDeployer;
+import xolpoc.spi.TaskDescriptorRepository;
+import xolpoc.spi.defaults.InMemoryTaskDescriptorRepository;
+import xolpoc.spi.receptor.ReceptorTaskDeployer;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Michael Minella
+ */
+@RestController
+@RequestMapping("/tasks")
+public class TaskController {
+
+	private final TaskDeployer deployer = new ReceptorTaskDeployer();
+
+	private final TaskDescriptorRepository repository =
+			new InMemoryTaskDescriptorRepository();
+
+	@RequestMapping
+	public Map<String, TaskStatus> listTasks() {
+		Map<String, TaskStatus> results = new HashMap<>();
+
+		for (Map.Entry<String, TaskDescriptor> entry : repository.findAll().entrySet()) {
+			TaskStatus status = deployer.getStatus(entry.getValue());
+
+			if(status == null) {
+				repository.delete(entry.getKey());
+			}
+			else {
+				results.put(entry.getKey(), status);
+			}
+		}
+
+		return results;
+	}
+
+	@RequestMapping(value = "/{name}", method = RequestMethod.POST)
+	public void createTask(@PathVariable("name") String name, @RequestBody String dsl) {
+		TaskDescriptor definition = repository.create(name, dsl);
+		deployer.deploy(definition);
+	}
+
+	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public void destroyTask(@PathVariable("name") String name) {
+		TaskDescriptor definition = repository.find(name);
+		if (definition == null) {
+			throw new IllegalArgumentException("unable to find definition for: " + name);
+		}
+
+		deployer.undeploy(definition);
+		repository.delete(name);
+	}
+}

--- a/src/main/java/xolpoc/model/TaskDescriptor.java
+++ b/src/main/java/xolpoc/model/TaskDescriptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xolpoc.model;
+
+import java.util.Map;
+
+/**
+ * @author Michael Minella
+ */
+public class TaskDescriptor {
+	private final String name;
+	private final String taskLabel;
+	private final String group;
+	private final Map<String, String> parameters;
+	private final String moduleName;
+
+	public TaskDescriptor(String name, String taskLabel, String group, Map<String, String> parameters, String moduleName) {
+		this.name = name;
+		this.taskLabel = taskLabel;
+		this.group = group;
+		this.parameters = parameters;
+		this.moduleName = moduleName;
+	}
+
+	public String getTaskLabel() {
+		return taskLabel;
+	}
+
+	public String getGroup() {
+		return group;
+	}
+
+	public Map<String, String> getParameters() {
+		return parameters;
+	}
+
+	public String getModuleName() {
+		return moduleName;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/main/java/xolpoc/model/TaskStatus.java
+++ b/src/main/java/xolpoc/model/TaskStatus.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xolpoc.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Michael Minella
+ */
+public class TaskStatus {
+
+	private final TaskDescriptor descriptor;
+
+	private final String id;
+
+	private final String state;
+
+	private final Map<String, String> attributes = new HashMap<>();
+
+	private final boolean failed;
+
+	private final String failedReason;
+
+
+	public TaskStatus(TaskDescriptor descriptor, String id, String state, boolean failed, String failedReason) {
+		this.descriptor = descriptor;
+		this.id = id;
+		this.state =  (StringUtils.hasText(state) ? state : "UNKNOWN");
+		this.failed = failed;
+		this.failedReason = failedReason;
+	}
+
+	public void addAttribute(String key, String value) {
+		this.attributes.put(key, value);
+	}
+
+	public TaskDescriptor getDescriptor() {
+		return descriptor;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public Map<String, String> getAttributes() {
+		return attributes;
+	}
+
+	public Boolean getFailed() {
+		return failed;
+	}
+
+	public String getFailedReason() {
+		return failedReason;
+	}
+}

--- a/src/main/java/xolpoc/spi/TaskDeployer.java
+++ b/src/main/java/xolpoc/spi/TaskDeployer.java
@@ -1,0 +1,16 @@
+package xolpoc.spi;
+
+import xolpoc.model.TaskDescriptor;
+import xolpoc.model.TaskStatus;
+
+/**
+ * @author Michael Minella
+ */
+public interface TaskDeployer {
+
+	void deploy(TaskDescriptor descriptor);
+
+	void undeploy(TaskDescriptor descriptor);
+
+	TaskStatus getStatus(TaskDescriptor descriptor);
+}

--- a/src/main/java/xolpoc/spi/TaskDescriptorRepository.java
+++ b/src/main/java/xolpoc/spi/TaskDescriptorRepository.java
@@ -1,0 +1,20 @@
+package xolpoc.spi;
+
+import java.util.Map;
+
+import xolpoc.model.TaskDescriptor;
+
+/**
+ * @author Michael Minella
+ */
+public interface TaskDescriptorRepository {
+
+	Map<String, TaskDescriptor> findAll();
+
+	TaskDescriptor find(String name);
+
+	TaskDescriptor create(String name, String dsl);
+
+	boolean delete(String name);
+
+}

--- a/src/main/java/xolpoc/spi/defaults/InMemoryTaskDescriptorRepository.java
+++ b/src/main/java/xolpoc/spi/defaults/InMemoryTaskDescriptorRepository.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xolpoc.spi.defaults;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import xolpoc.model.TaskDescriptor;
+import xolpoc.spi.TaskDescriptorRepository;
+
+/**
+ * @author Michael Minella
+ */
+public class InMemoryTaskDescriptorRepository implements TaskDescriptorRepository {
+
+	private final Map<String, TaskDescriptor> repository = new ConcurrentHashMap<>();
+
+	@Override
+	public Map<String, TaskDescriptor> findAll() {
+		return Collections.unmodifiableMap(repository);
+	}
+
+	@Override
+	public TaskDescriptor find(String name) {
+		return repository.get(name);
+	}
+
+	@Override
+	public TaskDescriptor create(String name, String dsl) {
+		String[] nameAndOptions = dsl.split("\\s", 2);
+		Map<String, String> parameters = new HashMap<>();
+
+		if (nameAndOptions.length == 2) {
+			String optionsString = nameAndOptions[1];
+			String[] optionTokens = optionsString.split("\\s");
+			for (String s : optionTokens) {
+				String[] kv = s.split("=", 2);
+				parameters.put(kv[0].replaceFirst("--", ""), kv[1]);
+			}
+		}
+
+		TaskDescriptor taskDescriptor = new TaskDescriptor(name, null, name, parameters, nameAndOptions[0]);
+
+		repository.put(name, taskDescriptor);
+
+		return taskDescriptor;
+	}
+
+	@Override
+	public boolean delete(String name) {
+		return repository.remove(name) != null;
+	}
+}

--- a/src/main/java/xolpoc/spi/receptor/ReceptorTaskDeployer.java
+++ b/src/main/java/xolpoc/spi/receptor/ReceptorTaskDeployer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xolpoc.spi.receptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.pivotal.receptor.actions.RunAction;
+import io.pivotal.receptor.client.ReceptorClient;
+import io.pivotal.receptor.commands.TaskCreateRequest;
+import io.pivotal.receptor.commands.TaskResponse;
+import io.pivotal.receptor.support.EnvironmentVariable;
+import xolpoc.model.TaskDescriptor;
+import xolpoc.model.TaskStatus;
+import xolpoc.spi.TaskDeployer;
+
+/**
+ * @author Michael Minella
+ */
+public class ReceptorTaskDeployer implements TaskDeployer {
+
+	public static final String DOCKER_PATH = "docker://192.168.59.103:5000/module-launcher";
+
+	private final ReceptorClient receptorClient = new ReceptorClient();
+
+	@Override
+	public void deploy(TaskDescriptor descriptor) {
+
+		//TODO Add endpoint callback to be able to have lattice notify admin that the task has been completed
+
+		Map<String, RunAction> action = new HashMap<>();
+		RunAction runAction = new RunAction();
+		runAction.setPath("java");
+		runAction.setArgs(new String[] {"-Djava.security.egd=file:/dev/./urandom", "-jar",
+				String.format("/opt/spring/modules/%s.jar", descriptor.getModuleName())});
+		action.put("run", runAction);
+
+		TaskCreateRequest request = new TaskCreateRequest();
+		request.setTaskGuid(guid(descriptor));
+		request.setRootfs(DOCKER_PATH);
+		request.setLogGuid(request.getTaskGuid());
+		request.setAction(action);
+
+		List<EnvironmentVariable> environmentVariables = new ArrayList<>();
+
+		Collections.addAll(environmentVariables, request.getEnv());
+
+		environmentVariables.add(new EnvironmentVariable("SPRING_PROFILES_ACTIVE", "cloud"));
+		Map<String, String> parameters = descriptor.getParameters();
+		if (parameters != null && parameters.size() > 0) {
+			for (Map.Entry<String, String> option : parameters.entrySet()) {
+				environmentVariables.add(
+						new EnvironmentVariable("OPTION_" + option.getKey(), option.getValue()));
+			}
+		}
+		request.setEnv(environmentVariables.toArray(new EnvironmentVariable[environmentVariables.size()]));
+
+		receptorClient.createTask(request);
+	}
+
+	private String guid(TaskDescriptor descriptor) {
+		return "xd-" + descriptor.getGroup() + "-" + descriptor.getModuleName();
+	}
+
+	private String path(TaskDescriptor descriptor) {
+		return descriptor.getGroup() + "." + descriptor.getModuleName();
+	}
+
+	@Override
+	public void undeploy(TaskDescriptor descriptor) {
+		receptorClient.deleteTask(guid(descriptor));
+	}
+
+	@Override
+	public TaskStatus getStatus(TaskDescriptor descriptor) {
+		TaskResponse task = null;
+		try {
+			task = receptorClient.getTask(guid(descriptor));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+		TaskStatus taskStatus = new TaskStatus(descriptor, task.getTaskGuid(), task.getState(), task.isFailed(), task.getFailureReason());
+
+		taskStatus.addAttribute("cellId", task.getCellId());
+		taskStatus.addAttribute("domain", task.getDomain());
+		taskStatus.addAttribute("processGuid", task.getTaskGuid());
+
+		return taskStatus;
+	}
+}


### PR DESCRIPTION
This POC demonstrates the execution of a Spring Boot jar file as a Diego
task.  Expecting the module to be located at
/opt/spring/modules/modulename.jar, the request to launch the
application will launch the uber jar and return when complete.  Status
of the task while executing and until cleaned up by Diego are also
available.
